### PR TITLE
Remove RFC 2119 language

### DIFF
--- a/draft-darling-key-directory-over-http.md
+++ b/draft-darling-key-directory-over-http.md
@@ -150,10 +150,10 @@ The following terms are used throughout this document:
 
 # Architecture
 
-An Origin is exposing a key directory for Clients to fetch. Clients MAY fetch the
+An Origin is exposing a key directory for Clients to fetch. Clients may fetch the
 directory from a Mirror, either to protect its privacy, or because the Origin
 wants to leverage a content delivery network. The endpoint and request pattern
-MUST be the same as if the fetch was to an Origin.
+should be the same as if the fetch was to an Origin.
 
 This document focuses on the below interaction, which is triggered when the
 Client does not have valid key for the Origin. This can be because the Client is
@@ -180,9 +180,9 @@ new, its cache is expired, or the Origin refuses requests with the current key s
 
 ## Key ID {#key-id}
 
-Each key in the directory MUST be associated with a unique Key ID.
+Each key in the directory is associated with a unique Key ID.
 
-Key ID MUST be derived from key material that is shared publicly.
+Key ID has to be derived from key material that is shared publicly.
 Protocols SHOULD provide the following blob of data:
 
 ~~~tls
@@ -191,7 +191,7 @@ struct {
 } PublicKeyMaterial;
 ~~~
 
-PublicKeyMaterial MAY be composed of both cryptographic material and metadata.
+PublicKeyMaterial may be composed of both cryptographic material and metadata.
 
 Key ID is defined has follow:
 
@@ -214,9 +214,9 @@ where
 ## Key Selection
 
 The following is a deterministic algorithm for determining which Key a Client
-SHOULD use to fulfill their cryptographic needs. By using a deterministic
+uses to fulfill their cryptographic needs. By using a deterministic
 algorithm, Origins can more easily predict the effects of a Key rotation and
-implement grace periods, soak times, etc. Protocols MAY place additional
+implement grace periods, soak times, etc. Protocols may place additional
 restrictions, or push these decision details to deployments.
 
 ### Algorithm
@@ -234,7 +234,7 @@ restrictions, or push these decision details to deployments.
 4. **Select the first key**: Choose the first key from the Key Directory, as
    ordered in the Key Directory format.
 
-Clients SHOULD implement the Key Selection Algorithm. Origins SHOULD present
+Clients should implement the Key Selection Algorithm. Origins should present
 the newest Keys first.
 
 For protocols which define a {{not-before}} field, the above algorithm minimizes the
@@ -246,15 +246,15 @@ to present their key directory so that the newest is always first, and
 the soon-to-be-removed key is last. This minimizes the chance of a client using
 an expired key.
 
-Expired key MAY be presented for completion, only if the protocol defines a
+Expired key may be presented for completion, only if the protocol defines a
 `not-after` field.
 
 ## Rotation {#rotation}
 
-Clients and Origins SHOULD NOT assume a key directory is fixed. Origins SHOULD
-rotate keys on a schedule. Clients SHOULD fetch keys upon an immediate rotation
-for security reasons. This section goes over how Origins SHOULD rotate their
-keys, and how that interacts with scheduled and immediate rotations.
+Key directories are not permanent: they change over time. Origins SHOULD
+rotate keys on a schedule. Clients are going to fetch keys upon an immediate
+rotation for security reasons. This section goes over how an Origin rotates
+its keys, and how that interacts with scheduled and immediate rotations.
 
 ### Algorithm
 
@@ -264,8 +264,8 @@ We approach a public key generation by the following function
 Generate(params, RAND) -> (publickey, privatekey, metadata)
 ~~~
 
-At any point in time, all keys in the directory MUST have a unique key id as defined in {{key-id}}.
-When adding a key in the directory, that key MUST have a unique key id.
+At any point in time, all keys in the directory have a unique key id as defined in {{key-id}}.
+When adding a key in the directory, that key has a unique key id.
 
 Generation looks as follows
 
@@ -280,39 +280,39 @@ while (key_id is not unique)
 ### Scheduled rotation
 
 Scheduled rotation happens at a time known to Origins, Clients, and Mirrors.
-This MAY be a regular interval (monthly, weekly, daily), or an ad-hoc schedule
+This may be a regular interval (monthly, weekly, daily), or an ad-hoc schedule
 agreed between all parties.
 
-Scheduled rotations MUST be communicated in one of the two mode below
+Scheduled rotations are communicated in one of the two mode below
 
 **Passive:**
 : Origins rely on cache headers to inform Clients about key expiry. They stop
   advertising the key at time `t`, and delete it at time `t_expiry=t+maxage`.
-  Origins MAY have to take intermediate mirrors into considerations, if they
+  Origins may have to take intermediate mirrors into considerations, if they
   are aware these mirrors don't respect their cache headers.
 
 **Active:**
-: Origins keep serving the key and add a `not-after` field. This field MUST be
+: Origins keep serving the key and add a `not-after` field. This field should be
   at least `t+maxage`.
 
-With both modes, an Origin SHOULD signal a key is not supported by sending a
-response with status code 400.
-It is RECOMMENDED to use key ID as defined in {{key-id}}.
+With both modes, an Origin has to signal a key is not supported by sending a
+response with status code 400. For instance, the error can include a key ID as
+defined in {{key-id}}.
 
 ### Immediate {#immediate}
 
-Origins MIGHT have to rotate keys immediately. Existing keys MAY
-have to be invalidated and/or new keys be provisioned. Immediate key rotation
-can happen in the event of a key compromise, loss, or other imperious reason.
+Origins might have to rotate keys immediately. Existing keys may have to be
+invalidated and/or new keys be provisioned. Immediate key rotation can happen in
+the event of a key compromise, loss, or other imperious reason.
 
 Immediate key rotation will cause some client requests to the server to fail
 until the client and mirrors retrieve a new version of the directory. The key
 directory endpoint is going to be placed under a higher load.
 
-1. Origins MAY introduce a random backoff to spread the load of key distribution
-   over time. See {{cache-behaviour}}
-2. Clients on a scheduled rotation MAY be configured to distrust rotation outside
-   a fixed window. Protocols SHOULD define such policies.
+1. Origins should consider introducing a random backoff to spread the load of
+   key distribution over time. See {{cache-behaviour}}
+2. Clients on a scheduled rotation should be configured to distrust rotation outside
+   a fixed window. Such policies should be defined by protocols.
 
 ## Cache behaviour {#cache-behaviour}
 
@@ -326,50 +326,52 @@ key, are at odds with each other. In the event of an {{immediate}} key rotation,
 Client might use an invalid key. However, if a Client fetches an Origin key
 directory for every request, it would waste time and network resources.
 
-This section provides interaction with some cache directive. Deployments SHOULD
+This section provides interaction with some cache directive. Deployments should
 also consider the recommendations laid out in {{Section 4.9 of HTTP-BEST-PRACTICES}}.
 
 ### `not-before` fields {#not-before}
 
-Protocols SHOULD define a `not-before` field. Origins SHOULD add a `not-before`
-field or equivalent to each Key in the Directory. The not-before field allows
+Protocols should define a `not-before` field. This field can be attached by Origins
+to each Key in the Directory. The `not-before` field allows
 Origins to signal to Clients when a Key is ready to use and reduces the
 chance a Client uses a key which is not yet available. not-before fields SHOULD
 be a Unix epoch timestamp in seconds.
 
 ### Cache directives
 
-Origins SHOULD respond with cache directives {{HTTP-CACHE}} which
-control when the Key Directory should be refreshed. Origins SHOULD provide a
+Origins responds with cache directives {{HTTP-CACHE}}. These
+control when the Key Directory should be refreshed. For instance, Origins
+provides a
 `Cache-Control: max-age` header, or `Expires` header which is slightly less than
-the grace period given for a key about to rotate. Clients SHOULD respect the
-`max-age` cache directive and MAY respect other directives. If an Origin
-provides a `max-age` header AND a Mirror is used, the Origin SHOULD provide a
+the grace period given for a key about to rotate. Clients should respect the
+`max-age` cache directive oe other directives. If an Origin
+provides a `max-age` header and a Mirror is used, an Origin should provide a
 `s-maxage` header that is equivalent to `max-age`.
 
 To prevent Clients refreshing their Key Directories at the same time
-(synchronization), Mirrors SHOULD provide to its clients a `max-age` cache
+(synchronization), Mirrors should provide to its clients a `max-age` cache
 directive with duration in the range `[0, Origin s-maxage]`.
 
-Origins SHOULD consider using `Date` ({{Section 6.6.1 of HTTP}}) and
+Origins should consider using `Date` ({{Section 6.6.1 of HTTP}}) and
 `Last-modified` ({{Section 8.8.2 of HTTP}}) headers to ease {{rotation}}.
 
 ### Client cache refresh
 
-The primary method a Client SHOULD use to determine when it refreshes its view
+The primary method a Client should use to determine when it refreshes its view
 of the Key Directory is through the delta seconds described in the `max-age`
 cache directive. The higher the delta, the less frequent a Client will update
 its cache. The lower the delta, the quicker clients will respond to unplanned
 key rotations.
 
-`min-fresh` MAY also be sent by Origins as defined in {{HTTP-CACHE}}.
+`min-fresh` could also be sent by Origins as defined in {{HTTP-CACHE}}.
 
 ## Well known URL
 
-It is RECOMMENDED protocol register a {{!WELL-KNOWN=RFC8615}} URL and associated
+It is recommended protocol register a {{!WELL-KNOWN=RFC8615}} URL and associated
 content-type.
 
-A key directory server MUST support both GET and HEAD request on that endpoint.
+A key directory server should consider supporting both GET and HEAD request on
+that endpoint.
 
 ~~~
 GET /.well-known/<your-protocol>
@@ -388,7 +390,7 @@ If issuing a `Last-Modified` header, the Origin server SHOULD support the correc
 response to a `If-Modified-Since` HTTP GET or HEAD request, returning the
 appropriate HTTP status codes {{HTTP-CACHE}}.
 
-It is RECOMMENDED that Mirrors support `Last-Modified` and `If-Modified-Since`
+It is recommended that Mirrors support `Last-Modified` and `If-Modified-Since`
 {{HTTP-CACHE}}.
 
 ## Future considerations
@@ -459,7 +461,7 @@ However, it does not addhere to the best practices laid down here, despite being
 Web keys. This would be valuable as the group aims to integrates with all sort
 of cryptographic keys, as can be seen with the new HPKE proposal {{JOSE-HPKE}}.
 
-Following these recommendations, JOSE MAY define:
+Following these recommendations, JOSE may define:
 
 * A well-known URI
 * A deterministic Key ID

--- a/draft-darling-key-directory-over-http.md
+++ b/draft-darling-key-directory-over-http.md
@@ -344,7 +344,7 @@ control when the Key Directory should be refreshed. For instance, Origins
 provides a
 `Cache-Control: max-age` header, or `Expires` header which is slightly less than
 the grace period given for a key about to rotate. Clients should respect the
-`max-age` cache directive oe other directives. If an Origin
+`max-age` cache directive or other directives. If an Origin
 provides a `max-age` header and a Mirror is used, an Origin should provide a
 `s-maxage` header that is equivalent to `max-age`.
 

--- a/draft-darling-key-directory-over-http.md
+++ b/draft-darling-key-directory-over-http.md
@@ -367,7 +367,7 @@ key rotations.
 
 ## Well known URL
 
-It is recommended protocol register a {{!WELL-KNOWN=RFC8615}} URL and associated
+It is recommended protocols register a {{!WELL-KNOWN=RFC8615}} URL and associated
 content-type.
 
 A key directory server should consider supporting both GET and HEAD request on


### PR DESCRIPTION
in its current format, the draft is about recommendations. removing normative RFC 2119 language.

There are things that would actually be nice to define with a normative draft (thinking about all directories having a well know, a key id, or using http cache headers). These is input we'd take from the dispatch.